### PR TITLE
chore(hmr): add initial hot-module-replacement example

### DIFF
--- a/examples/hot-module-replacement/package.json
+++ b/examples/hot-module-replacement/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "hot-module-replacement",
+  "version": "0.1.0",
+  "description": "A simple demonstration of webpack's Hot Module Replacement feature",
+  "main": "index.js",
+  "scripts": {
+    "start": "webpack-dev-server"
+  },
+  "author": "Greg Venech",
+  "license": "ISC",
+  "devDependencies": {
+    "html-webpack-plugin": "^2.29.0",
+    "webpack": "^3.3.0",
+    "webpack-dev-server": "^2.5.1"
+  }
+}

--- a/examples/hot-module-replacement/src/index.js
+++ b/examples/hot-module-replacement/src/index.js
@@ -6,5 +6,5 @@ if (module.hot) {
   module.hot.accept('./library', function() {
     console.log('Accepting the updated library module!');
     Library.log();
-  })
+  });
 }

--- a/examples/hot-module-replacement/src/index.js
+++ b/examples/hot-module-replacement/src/index.js
@@ -1,0 +1,10 @@
+import Library from './library';
+
+Library.log();
+
+if (module.hot) {
+  module.hot.accept('./library', function() {
+    console.log('Accepting the updated library module!');
+    Library.log();
+  })
+}

--- a/examples/hot-module-replacement/src/library.js
+++ b/examples/hot-module-replacement/src/library.js
@@ -1,0 +1,6 @@
+export default {
+  log() {
+    // Change this after the server is started to test
+    console.log('First log...')
+  }
+}

--- a/examples/hot-module-replacement/src/library.js
+++ b/examples/hot-module-replacement/src/library.js
@@ -3,4 +3,4 @@ export default {
     // Change this after the server is started to test
     console.log('First log...');
   }
-}
+};

--- a/examples/hot-module-replacement/src/library.js
+++ b/examples/hot-module-replacement/src/library.js
@@ -1,6 +1,6 @@
 export default {
   log() {
     // Change this after the server is started to test
-    console.log('First log...')
+    console.log('First log...');
   }
 }

--- a/examples/hot-module-replacement/webpack.config.js
+++ b/examples/hot-module-replacement/webpack.config.js
@@ -1,0 +1,24 @@
+const path = require('path');
+const webpack = require('webpack');
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+
+module.exports = {
+  entry: './src/index.js',
+  plugins: [
+    new webpack.HotModuleReplacementPlugin(),
+    new webpack.NamedModulesPlugin(),
+    new HtmlWebpackPlugin({
+      title: 'Hot Module Replacement'
+    })
+  ],
+  output: {
+    filename: '[name].bundle.js',
+    path: path.resolve(__dirname, './dist'),
+    publicPath: '/'
+  },
+  devServer: {
+    hot: true,
+    port: 8081,
+    contentBase: path.resolve(__dirname, './dist'),
+  }
+};


### PR DESCRIPTION
I had this one sitting around too -- it'll probably need some work to synchronize it with the actual guide, esp. after webpack/webpack.js.org#1439 is merged, however this should be a good starting point. It also a good baseline for issues like webpack/webpack.js.org#1443.